### PR TITLE
ignore request paths

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Uinta.MixProject do
       app: :uinta,
       name: "Uinta",
       description: "Simpler structured logs and lower log volume for Elixir apps",
-      version: "0.4.2",
+      version: "0.5.0",
       elixir: "~> 1.8",
       source_url: @project_url,
       homepage_url: @project_url,


### PR DESCRIPTION
When an `ignored_paths` option is given to `Uinta.Plug`, requests to
those paths will no longer be logged out unless the HTTP status returned
is not a 200-level status.