### PR TITLE
Alter Uinta.Plug to better handle non-string query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
  # CHANGELOG
 
+## v0.9.2 - 2022-03-08
+
+### Changed
+* Doesn't crash when "query" is not a string
 
  ## v0.9.1 - 2022-01-21
 

--- a/lib/uinta/plug.ex
+++ b/lib/uinta/plug.ex
@@ -220,10 +220,10 @@ if Code.ensure_loaded?(Plug) do
     defp variables(_), do: nil
 
     @spec graphql_info(Plug.Conn.t(), opts()) :: graphql_info() | nil
-    defp graphql_info(%{method: "POST", params: params}, opts) do
+    defp graphql_info(%{method: "POST", params: params = %{"query" => query}}, opts)
+         when is_binary(query) do
       type =
-        params["query"]
-        |> Kernel.||("")
+        query
         |> String.trim()
         |> query_type()
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Uinta.MixProject do
       app: :uinta,
       name: "Uinta",
       description: "Simpler structured logs and lower log volume for Elixir apps",
-      version: "0.9.1",
+      version: "0.9.2",
       elixir: "~> 1.8",
       source_url: @project_url,
       homepage_url: @project_url,

--- a/test/uinta/plug_test.exs
+++ b/test/uinta/plug_test.exs
@@ -140,6 +140,17 @@ defmodule Uinta.PlugTest do
     assert message =~ ~r"\[info\]  QUERY getUser \(/graphql\) - Sent 200 in [0-9]+[µm]s"u
   end
 
+  test "does not try to parse query details from non-string 'query' params" do
+    params = %{"query" => ["query FakeQuery {}"]}
+
+    message =
+      capture_log(fn ->
+        MyPlug.call(conn(:post, "/hello/world", params), [])
+      end)
+
+    assert message =~ ~r"\[info\]  POST /hello/world - Sent 200 in [0-9]+[µm]s"u
+  end
+
   test "logs proper json to console" do
     message =
       capture_log(fn ->


### PR DESCRIPTION
For POST requests with non-string parameters named "query", `Uinta.Plug` raises an exception because it passes the non-string values to `String.trim/1`. This pull request changes the behavior to not attempt parsing GraphQL details from "query" params that are not strings.