### PR TITLE
remove remapping of the status field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
  # CHANGELOG
 
+ ## v0.10.2 - 2022-05-31
+
+### Added
+* Removed remapping for status as done in Datadog directly
+
  ## v0.10.1 - 2022-05-31
 
 ### Added

--- a/lib/uinta/plug.ex
+++ b/lib/uinta/plug.ex
@@ -175,7 +175,6 @@ if Code.ensure_loaded?(Plug) do
       case opts[:include_datadog_fields] do
         true ->
           dd_fields = %{
-            "status" => Logger.level(),
             "http.url" => info[:path],
             "http.status_code" => conn.status,
             "http.method" => info[:method],

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Uinta.MixProject do
       app: :uinta,
       name: "Uinta",
       description: "Simpler structured logs and lower log volume for Elixir apps",
-      version: "0.10.1",
+      version: "0.10.2",
       elixir: "~> 1.8",
       source_url: @project_url,
       homepage_url: @project_url,


### PR DESCRIPTION
Need to remove the status field as it will conflict with our setup and is handled in Datadog really (per their recommendation)