### PR TITLE
add error into returned string to log out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
  # CHANGELOG
 
+ ## v0.10.3 - 2022-07-19
+
+### Changed
+* Log out error on rescue when we are unable to format
+
  ## v0.10.2 - 2022-05-31
 
 ### Added

--- a/lib/uinta/formatter/datadog.ex
+++ b/lib/uinta/formatter/datadog.ex
@@ -41,7 +41,6 @@ defmodule Uinta.Formatter.Datadog do
     |> Util.encode()
   rescue
     e ->
-      IO.inspect(e)
       "Could not format: #{inspect({level, message, metadata})}, Due to error: #{inspect(e)}"
   end
 

--- a/lib/uinta/formatter/datadog.ex
+++ b/lib/uinta/formatter/datadog.ex
@@ -42,7 +42,7 @@ defmodule Uinta.Formatter.Datadog do
   rescue
     e ->
       IO.inspect(e)
-      "Could not format: #{inspect({level, message, metadata})}"
+      "Could not format: #{inspect({level, message, metadata})}, Due to error: #{inspect(e)}"
   end
 
   @spec add_datadog_trace(map(), Keyword.t()) :: map()
@@ -54,7 +54,7 @@ defmodule Uinta.Formatter.Datadog do
 
   defp to_datadog_id(id) when is_nil(id), do: nil
 
-  defp to_datadog_id(<<high::bytes-size(16)>><><<low::bytes-size(16)>>) do
+  defp to_datadog_id(<<high::bytes-size(16)>> <> <<low::bytes-size(16)>>) do
     #  OpenTelemetry uses 128 bits for the trace id and 64 bits for the span id.
     #  DataDog uses the lower 64 bits of each, as an unsigned integer, for its trace/span ids.
     to_datadog_id(low)

--- a/lib/uinta/formatter/standard.ex
+++ b/lib/uinta/formatter/standard.ex
@@ -16,6 +16,7 @@ defmodule Uinta.Formatter.Standard do
   def format(level, message, timestamp, metadata) do
     Util.format(level, message, timestamp, metadata) |> Util.encode()
   rescue
-    _ -> "Could not format: #{inspect({level, message, metadata})}"
+    e ->
+      "Could not format: #{inspect({level, message, metadata})}, Due to error: #{inspect(e)}"
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Uinta.MixProject do
       app: :uinta,
       name: "Uinta",
       description: "Simpler structured logs and lower log volume for Elixir apps",
-      version: "0.10.2",
+      version: "0.10.3",
       elixir: "~> 1.8",
       source_url: @project_url,
       homepage_url: @project_url,


### PR DESCRIPTION
We just saw an issue with the Uinta upgrades Walker was working on specifically in our Application
We rolled back the Application change for now.
After looking at Uinta I see we are not logging the error case in the rescue in the error case we were seeing.