### PR TITLE
Add support for dynamic log level in Uinta.Plug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
  # CHANGELOG
 
+## v0.14.0 (2024-04-16)
+* Support dynamic log level in `Uinta.Plug`.
+  * Option `:log` now accepts `{module, function, args}` tuple called with prepended `conn` to determine log level.
+
 ## v0.13.0 (2024-01-09)
 ### Changed
   * Support not double encoding the payload. In order to do that, a new plugs option `format` was added. We are deprecating the `json` option instead though it is backward compatible for a little while

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Uinta.MixProject do
   use Mix.Project
 
   @project_url "https://github.com/podium/uinta"
-  @version "0.13.0"
+  @version "0.14.0"
 
   def project do
     [


### PR DESCRIPTION
I received a request for 500-level responses to get logged with a level of `:error`, but Uinta does not currently support log levels that change based on the status code (conn-ditions?). Without thinking through the issue in its entirety I would maybe be of the opinion that meta-logs about requests/responses are always informational and for 500-level responses the reason they're 500-level ought to be logged at the appropriate level. The request, however, does not seem unreasonable, and [`Phoenix.Logger` supports dynamic log level](https://hexdocs.pm/phoenix/Phoenix.Logger.html#module-dynamic-log-level), so I'm proposing it for Uinta.