### PR TITLE
feat: Allow for Custom Status Codes to Be Sampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Changed
 
 * Allows for custom sampled status codes to be specified. These are still honored
-  by the `success_log_sampling_ratio` option, even if they are not traditionally
+  by the `success_log_sampling_ratio` option, even if they may not be traditional
   'successful' status codes.
+* Adds a `Uinta.Plug.default_sampled_status_codes/0` function to return the default sampled status codes.
+  These are now explicitly listed, instead of just being all 1xx and 2xx integers.
 
 ## v0.15.1 (2024-12-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
  # CHANGELOG
 
+## v0.16.0 (2025-09-12)
+
+### Changed
+
+* Allows for custom sampled status codes to be specified. These are still honored
+  by the `success_log_sampling_ratio` option, even if they are not traditionally
+  'successful' status codes.
+
 ## v0.15.1 (2024-12-04)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ You can also perform log sampling by setting the `success_log_sampling_ratio`. F
 plug Uinta.Plug, success_log_sampling_ratio: 0.2
 ```
 
+You can also specify custom sampled status codes to be logged. This is useful if you want to sample out
+ more than just the default 1xx and 2xx status codes. The following is a 20% log sampling with custom sampled status codes:
+
+```elixir
+plug Uinta.Plug,
+  success_log_sampling_ratio: 0.2,
+  sampled_status_codes: Uinta.Plug.default_sampled_status_codes() ++ [401]
+```
+
 If your endpoint didn't call `Plug.Logger`, add the above line above the line
 that looks like this:
 

--- a/lib/uinta/plug.ex
+++ b/lib/uinta/plug.ex
@@ -111,7 +111,8 @@ if Code.ensure_loaded?(Plug) do
             include_variables: boolean(),
             include_datadog_fields: boolean(),
             ignored_paths: list(String.t()),
-            filter_variables: list(String.t())
+            filter_variables: list(String.t()),
+            sampled_status_codes: list(non_neg_integer())
           }
 
     @impl Plug
@@ -133,6 +134,7 @@ if Code.ensure_loaded?(Plug) do
         include_variables: Keyword.get(opts, :include_variables, false),
         filter_variables: Keyword.get(opts, :filter_variables, @default_filter),
         include_datadog_fields: Keyword.get(opts, :include_datadog_fields, false),
+        sampled_status_codes: Keyword.get(opts, :sampled_status_codes, 0..299),
         success_log_sampling_ratio:
           Keyword.get(
             opts,
@@ -373,7 +375,7 @@ if Code.ensure_loaded?(Plug) do
 
     defp should_log_request?(conn, opts) do
       cond do
-        is_integer(conn.status) and conn.status >= 300 ->
+        is_integer(conn.status) and conn.status not in opts.sampled_status_codes ->
           # log all HTTP status >= 300 (usually errors)
           true
 

--- a/lib/uinta/plug.ex
+++ b/lib/uinta/plug.ex
@@ -94,6 +94,22 @@ if Code.ensure_loaded?(Plug) do
 
     @default_filter ~w(password passwordConfirmation idToken refreshToken)
     @default_sampling_ratio 1.0
+    @default_sampled_status_codes [
+      100,
+      101,
+      102,
+      103,
+      200,
+      201,
+      202,
+      203,
+      204,
+      205,
+      206,
+      207,
+      208,
+      226
+    ]
 
     @query_name_regex ~r/^\s*(?:query|mutation)\s+(\w+)|{\W+(\w+)\W+?{/m
 
@@ -134,7 +150,8 @@ if Code.ensure_loaded?(Plug) do
         include_variables: Keyword.get(opts, :include_variables, false),
         filter_variables: Keyword.get(opts, :filter_variables, @default_filter),
         include_datadog_fields: Keyword.get(opts, :include_datadog_fields, false),
-        sampled_status_codes: Keyword.get(opts, :sampled_status_codes, 0..299),
+        sampled_status_codes:
+          Keyword.get(opts, :sampled_status_codes, @default_sampled_status_codes),
         success_log_sampling_ratio:
           Keyword.get(
             opts,
@@ -143,6 +160,19 @@ if Code.ensure_loaded?(Plug) do
           )
       }
     end
+
+    @doc """
+    Returns the default sampled status codes. These are all 1xx and 2xx status codes
+    according to the original HTTP RFC, and inclusions from the Wikipedia article on
+    HTTP status codes.
+
+    It's recommended to extend this list with your own status codes if you want to sample more than the default.
+
+    - [RFC](https://datatracker.ietf.org/doc/html/rfc2616#section-6.1.1)
+    - [Wikipedia](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
+    """
+    @spec default_sampled_status_codes() :: list(non_neg_integer())
+    def default_sampled_status_codes, do: @default_sampled_status_codes
 
     @impl Plug
     def call(conn, opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Uinta.MixProject do
   use Mix.Project
 
   @project_url "https://github.com/podium/uinta"
-  @version "0.15.1"
+  @version "0.16.0"
 
   def project do
     [

--- a/test/uinta/plug_test.exs
+++ b/test/uinta/plug_test.exs
@@ -22,7 +22,7 @@ defmodule Uinta.PlugTest do
 
     plug(Uinta.Plug,
       success_log_sampling_ratio: 0,
-      sampled_status_codes: Enum.to_list(0..299) ++ [401]
+      sampled_status_codes: Uinta.Plug.default_sampled_status_codes() ++ [401]
     )
 
     plug(:passthrough)
@@ -554,12 +554,7 @@ defmodule Uinta.PlugTest do
     assert message =~ "MUTATION CreateReviewForEpisode"
   end
 
-  test "logs custom sampled status codes" do
-    message = capture_log(fn -> MyPlugWithCustomSampledStatusCodes.call(conn(:get, "/"), []) end)
-    refute message =~ "GET / - Sent 401 in [0-9]+[µm]s"
-  end
-
-  test "does not log custom sampled status codes when they are not in the list" do
+  test "does not log custom sampled status codes when they are in the configured sampled status codes" do
     message = capture_log(fn -> MyPlugWithCustomSampledStatusCodes.call(conn(:get, "/"), []) end)
     refute message =~ "GET / - Sent 401 in [0-9]+[µm]s"
   end


### PR DESCRIPTION
I have a public web app that has an expected number of 401s/422s/etc that are not being sampled out by Uinta, and end up polluting my logs. This PR makes it so I can pass in a list of allowed HTTP status codes to be considered as part of the 'success' logs, and sampled according to the existing logic.